### PR TITLE
UI改善: ナビゲーションメニューとカルーセル画像表示の修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,10 +96,6 @@
     <nav>
         <div class="nav-container">
             <div class="logo">🀄 麻雀ドリル</div>
-            <ul class="nav-links">
-                <li><a href="#home">ホーム</a></li>
-                <li><a href="#apps">アプリ詳細</a></li>
-            </ul>
         </div>
     </nav>
 

--- a/styles.css
+++ b/styles.css
@@ -202,6 +202,7 @@ nav {
 
 /* 縦画面のアプリ画像用のパディング */
 .screenshot-item img[src*="nanikiru001.png"],
+.screenshot-item img[src*="nanikiru_haikouritsu001.png"],
 .screenshot-item img[src*="nanikiru_haikouritsu002.png"] {
     max-width: 70%;
     padding: 20px;


### PR DESCRIPTION
## Summary
- ナビゲーションから不要な「ホーム」「アプリ詳細」リンクを削除
- ヒーローセクションのカルーセルで3枚目の画像が異常に大きく表示される問題を修正

## Test plan
- [ ] ナビゲーションメニューが正しく表示されることを確認
- [ ] ヒーローセクションのカルーセルで全ての画像が適切なサイズで表示されることを確認
- [ ] レスポンシブデザインが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)